### PR TITLE
add aluft box support and name highlighting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.27'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -27,8 +27,8 @@ dependencies {
 
 group = 'io.github.mmagicala.gnomeRestaurant'
 version = '1.3'
-sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+    options.release.set(11)
 }

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantConfig.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantConfig.java
@@ -26,6 +26,9 @@
 
 package io.github.mmagicala.gnomeRestaurant;
 
+import io.github.mmagicala.gnomeRestaurant.data.UniqueRecipient;
+import java.util.Collections;
+import java.util.Set;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -86,5 +89,17 @@ public interface GnomeRestaurantConfig extends Config
 	default boolean showWorldMapPoint()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = GnomeRestaurantPlugin.HIGHLIGHTED_RECIPIENTS,
+		name = "Highlighted Names",
+		description = "Configures recipient names to highlight" +
+			"<br>These recipients can award unique items as a tip",
+		position = 5
+	)
+	default Set<UniqueRecipient> highlightedRecipients()
+	{
+		return Collections.emptySet();
 	}
 }

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantConfig.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantConfig.java
@@ -36,7 +36,8 @@ public interface GnomeRestaurantConfig extends Config
 	@ConfigItem(
 		keyName = GnomeRestaurantPlugin.SHOW_OVERLAY,
 		name = "Show Overlay",
-		description = "Configures whether to show the overlay window"
+		description = "Configures whether to show the overlay window",
+		position = 0
 	)
 	default boolean showOverlay()
 	{
@@ -46,7 +47,8 @@ public interface GnomeRestaurantConfig extends Config
 	@ConfigItem(
 		keyName = GnomeRestaurantPlugin.SHOW_ORDER_TIMER,
 		name = "Show Order Timer",
-		description = "Configures whether to show the order timer"
+		description = "Configures whether to show the order timer",
+		position = 1
 	)
 	default boolean showOrderTimer()
 	{
@@ -56,7 +58,8 @@ public interface GnomeRestaurantConfig extends Config
 	@ConfigItem(
 		keyName = GnomeRestaurantPlugin.SHOW_DELAY_TIMER,
 		name = "Show Delay Timer",
-		description = "Configures whether to show the order delay timer"
+		description = "Configures whether to show the order delay timer",
+		position = 2
 	)
 	default boolean showDelayTimer()
 	{
@@ -66,7 +69,8 @@ public interface GnomeRestaurantConfig extends Config
 	@ConfigItem(
 		keyName = GnomeRestaurantPlugin.SHOW_HINT_ARROW,
 		name = "Show Hint Arrow",
-		description = "Configures whether to show the hint arrow toward the order recipient"
+		description = "Configures whether to show the hint arrow toward the order recipient",
+		position = 3
 	)
 	default boolean showHintArrow()
 	{
@@ -76,7 +80,8 @@ public interface GnomeRestaurantConfig extends Config
 	@ConfigItem(
 		keyName = GnomeRestaurantPlugin.SHOW_WORLD_MAP_POINT,
 		name = "Show World Map Point",
-		description = "Configures whether to show the recipient's location in the world map"
+		description = "Configures whether to show the recipient's location in the world map",
+		position = 4
 	)
 	default boolean showWorldMapPoint()
 	{

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/data/UniqueRecipient.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/data/UniqueRecipient.java
@@ -1,0 +1,33 @@
+package io.github.mmagicala.gnomeRestaurant.data;
+
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UniqueRecipient
+{
+	NINTO("Captain Ninto"),
+	DAERKIN("Captain Daerkin"),
+	WINGSTONE("Wingstone"),
+	PENWIE("Penwie"),
+	BRAMBICKLE("Brambickle"),
+	MANGLETHORP("Professor Manglethorp");
+
+	private static final UniqueRecipient[] VALUES = UniqueRecipient.values();
+	private final String name;
+
+	public static @Nullable UniqueRecipient byName(final String name)
+	{
+		for (final var v : VALUES)
+		{
+			if (v.name.equals(name))
+			{
+				return v;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
This adds:

- widget parsing of [aluft box](https://oldschool.runescape.wiki/w/Aluft_aloft_box) text to update plugin
- text highlighting of recipient names that can give unique items

Sometimes the name of the food to make is not given by Gianne jnr. and therefore the plugin does not update for the current task. This might only occur when the [reward token](https://oldschool.runescape.wiki/w/Reward_token_(Gnome_Restaurant)) is maxed out?

Example:

<img width="928" height="256" alt="1" src="https://github.com/user-attachments/assets/4ffa7c0f-605a-4d96-87b1-b97a04c6f2bf" />

Parsing the aluft box message provides a way to resync the plugin for the current task. It also enables resyncing the plugin if you happen to log out during a task.