### PR TITLE
fix: don't treat cocktail glass as intermediate

### DIFF
--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/recipe/Order.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/recipe/Order.java
@@ -501,7 +501,7 @@ public enum Order {
         // Mixed cocktail -> poured cocktail
 
         List<Ingredient> ingredients = new ArrayList<>();
-        ingredients.add(new Ingredient(ItemID.COCKTAIL_GLASS_EMPTY, 1, true));
+        ingredients.add(new Ingredient(ItemID.COCKTAIL_GLASS_EMPTY, 1));
         ingredients.add(new Ingredient(mixedItem, 1, true));
         ingredients.addAll(pouredIngredients);
 


### PR DESCRIPTION
(A little something that was bothering me. I had the code open, so thought I would fix it.)

To my understanding, intermediate ingredientes are those that are created during the prepping. That is, we don't want the unfinished cocktail appearing as "future ingredientes", which makes sense. The glass, however, is something you need to buy before/while prepping.

I almost always end up forgetting to buy it as it doesn't appear on the overlay under future ingredients, so this fixes it.