### PR TITLE
feat: customer+order info in overlay, plus unique rewards

### DIFF
--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantPlugin.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/GnomeRestaurantPlugin.java
@@ -110,7 +110,7 @@ public class GnomeRestaurantPlugin extends Plugin {
 
     // Overlay
 
-    private OverlayHeader overlayHeader = new OverlayHeader("null", -1, -1);
+    private OverlayHeader overlayHeader = new OverlayHeader("null", -1, -1, customer, order);
     private final List<OverlayTableEntry> stepIngredientsOverlayTable = new ArrayList<>();
     private final List<OverlayTableEntry> nextRawIngredientsOverlayTable = new ArrayList<>();
 
@@ -384,7 +384,7 @@ public class GnomeRestaurantPlugin extends Plugin {
 
     private void updateOverlayHeader() {
         var instruction = order.getSteps().get(stepIdx).getInstruction().getOverlayDirections();
-        overlayHeader = new OverlayHeader(instruction, stepIdx + 1, order.getSteps().size());
+        overlayHeader = new OverlayHeader(instruction, stepIdx + 1, order.getSteps().size(), customer, order);
     }
 
     private void rebuildOverlayTables() {

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/order/Customer.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/order/Customer.java
@@ -5,6 +5,8 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.NpcID;
 
 import java.security.InvalidParameterException;
+import java.util.Arrays;
+import java.util.List;
 
 public enum Customer {
 
@@ -32,16 +34,16 @@ public enum Customer {
     // Hard NPCs
     HAZELMERE(101, "Hazelmere", CustomerLocation.fixed(NpcID.GRANDTREE_HAZELMERE_MULTI, 2678, 3086)),
     GNORMADIUM_AVLAFRIM(102, "Gnormadium Avlafrim", CustomerLocation.fixed(NpcID.GNORMADIUM_AVLAFRIM_GLIDER, 2544, 2973)),
-    CAPTAIN_NINTO(103, "Captain Ninto", CustomerLocation.fixed(NpcID.ALUFT_PILOT_NINTO, 2869, 9877)),
-    CAPTAIN_DAERKIN(104, "Captain Daerkin", CustomerLocation.fixed(NpcID.ALUFT_PILOT_DAERKIN, 3355, 3210)),
-    BRAMBICKLE(105, "Brambickle", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_MOUNTAIN, 2786, 3862)),
-    WINGSTONE(106, "Wingstone", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_SAFARI, 3380, 2893)),
-    PENWIE(107, "Penwie", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_JUNGLE, 2932, 2972)),
+    CAPTAIN_NINTO(103, "Captain Ninto", CustomerLocation.fixed(NpcID.ALUFT_PILOT_NINTO, 2869, 9877), Arrays.asList(Reward.GOGGLES, Reward.SCARF)),
+    CAPTAIN_DAERKIN(104, "Captain Daerkin", CustomerLocation.fixed(NpcID.ALUFT_PILOT_DAERKIN, 3355, 3210), Arrays.asList(Reward.GOGGLES, Reward.SCARF)),
+    BRAMBICKLE(105, "Brambickle", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_MOUNTAIN, 2786, 3862), Arrays.asList(Reward.SEED_PODS, Reward.MINT_CAKE)),
+    WINGSTONE(106, "Wingstone", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_SAFARI, 3380, 2893), Arrays.asList(Reward.SEED_PODS, Reward.MINT_CAKE)),
+    PENWIE(107, "Penwie", CustomerLocation.fixed(NpcID.ALUFT_GNOME_EXPLORER_JUNGLE, 2932, 2972), Arrays.asList(Reward.SEED_PODS, Reward.MINT_CAKE)),
     AMBASSADOR_GIMBLEWAP(108, "Ambassador Gimblewap", CustomerLocation.fixed(NpcID.ALUFT_GNOME_DIPLOMAT_ARDOUGNE, 2572, 3299)),
     AMBASSADOR_SPANFIPPLE(109, "Ambassador Spanfipple", CustomerLocation.fixed(NpcID.ALUFT_GNOME_DIPLOMAT_FALADOR, 2984, 3342, 1)),
     AMBASSADOR_FERRNOOK(110, "Ambassador Ferrnook", CustomerLocation.fixed(NpcID.ALUFT_GNOME_DIPLOMAT_VARROCK, 3209, 3474)),
     PROFESSOR_IMBLEWYN(111, "Professor Imblewyn", CustomerLocation.fixed(NpcID.ALUFT_GNOME_MAGE_2, 2590, 3092)),
-    PROFESSOR_MANGLETHORP(112, "Professor Manglethorp", CustomerLocation.fixed(NpcID.ALUFT_GNOME_INVENTOR, 2868, 10198)),
+    PROFESSOR_MANGLETHORP(112, "Professor Manglethorp", CustomerLocation.fixed(NpcID.ALUFT_GNOME_INVENTOR, 2868, 10198), Arrays.asList(Reward.SEED_PODS)),
     PROFESSOR_ONGLEWIP(113, "Professor Onglewip", CustomerLocation.fixed(NpcID.ALUFT_GNOME_MAGE, 3115, 3160)),
     GARKOR(114, "Garkor", new GarkorLocation()),
     KING_BOLREN(115, "King Bolren", CustomerLocation.fixed(NpcID.KING_BOLREN, 2542, 3169)),
@@ -54,6 +56,7 @@ public enum Customer {
     private final int id;
     private final String name;
     private final CustomerLocation location;
+    private final List<Reward> uniqueRewards;
 
     public static Customer forId(int id) {
         for (var recipient : values()) {
@@ -64,10 +67,17 @@ public enum Customer {
         throw new InvalidParameterException("No customer found with the id " + id);
     }
 
+    Customer(int id, String name, CustomerLocation location, List<Reward> uniqueRewards) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.uniqueRewards = uniqueRewards;
+    }
     Customer(int id, String name, CustomerLocation location) {
         this.id = id;
         this.name = name;
         this.location = location;
+        this.uniqueRewards = Arrays.asList();
     }
 
     public String getName() {
@@ -84,5 +94,9 @@ public enum Customer {
 
     public WorldPoint getLocation(Client client) {
         return this.location.resolve(client);
+    }
+
+    public List<Reward> getUniqueRewards() {
+        return this.uniqueRewards;
     }
 }

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/order/Reward.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/order/Reward.java
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright (c) 2020, MMagicala <https://github.com/MMagicala>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.github.mmagicala.gnomeRestaurant.order;
+
+import net.runelite.api.gameval.ItemID;
+
+public enum Reward {
+    GOGGLES(ItemID.ALUFT_GNOME_GOGGLES),
+    SCARF(ItemID.ALUFT_GNOME_SCARF),
+    SEED_PODS(ItemID.ALUFT_SEED_POD),
+    MINT_CAKE(ItemID.ALUFT_GNOME_MINT_CAKE);
+
+    private final int itemId;
+
+    Reward(int itemId) {
+        this.itemId = itemId;
+    }
+
+    public int getItemId() {
+        return this.itemId;
+    }
+}

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/GnomeRestaurantOverlay.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/GnomeRestaurantOverlay.java
@@ -77,6 +77,9 @@ public class GnomeRestaurantOverlay extends OverlayPanel {
     private void renderOrderOverlay(OverlayHeader header) {
         String headerCustomerText = header.order.getName() + " to " + header.customer.getName();
         LineComponent headerCustomerComponent = LineComponent.builder().left(headerCustomerText).build();
+        if (!header.customer.getUniqueRewards().isEmpty()) {
+            headerCustomerComponent.setLeftColor(Color.CYAN);
+        }
         panelComponent.getChildren().add(headerCustomerComponent);
 
         String headerStepText = "Step " + header.stepNum + "/" + header.totalSteps + ": " + header.instruction;

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/GnomeRestaurantOverlay.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/GnomeRestaurantOverlay.java
@@ -69,14 +69,19 @@ public class GnomeRestaurantOverlay extends OverlayPanel {
 
     @Override
     public Dimension render(Graphics2D graphics) {
-        // Header
         var header = plugin.overlayHeader();
-        String headerText = "Step " + header.stepNum + "/" + header.totalSteps + ": " + header.instruction;
+        renderOrderOverlay(header);
+        return super.render(graphics);
+    }
 
-        LineComponent headerComponent = LineComponent.builder().left(headerText).build();
-        panelComponent.getChildren().add(headerComponent);
+    private void renderOrderOverlay(OverlayHeader header) {
+        String headerCustomerText = header.order.getName() + " to " + header.customer.getName();
+        LineComponent headerCustomerComponent = LineComponent.builder().left(headerCustomerText).build();
+        panelComponent.getChildren().add(headerCustomerComponent);
 
-        // Overlay tables
+        String headerStepText = "Step " + header.stepNum + "/" + header.totalSteps + ": " + header.instruction;
+        LineComponent headerStepComponent = LineComponent.builder().left(headerStepText).build();
+        panelComponent.getChildren().add(headerStepComponent);
 
         renderOverlayTable(stepIngredientsOverlayTable, "Current Step");
 
@@ -84,8 +89,6 @@ public class GnomeRestaurantOverlay extends OverlayPanel {
             // Only render future ingredients if there are any left
             renderOverlayTable(futureRawIngredientsOverlayTable, "Needed Later");
         }
-
-        return super.render(graphics);
     }
 
     private void renderOverlayTable(List<OverlayTableEntry> overlayTable, String title) {

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/OverlayHeader.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/overlay/OverlayHeader.java
@@ -1,14 +1,21 @@
 package io.github.mmagicala.gnomeRestaurant.overlay;
 
+import io.github.mmagicala.gnomeRestaurant.order.Customer;
+import io.github.mmagicala.gnomeRestaurant.recipe.Order;
+
 public class OverlayHeader {
 
     public final String instruction;
     public final int stepNum;
     public final int totalSteps;
+    public final Customer customer;
+    public final Order order;
 
-    public OverlayHeader(String instruction, int stepNum, int totalSteps) {
+    public OverlayHeader(String instruction, int stepNum, int totalSteps, Customer customer, Order order) {
         this.instruction = instruction;
         this.stepNum = stepNum;
         this.totalSteps = totalSteps;
+        this.customer = customer;
+        this.order = order;
     }
 }

--- a/src/main/java/io/github/mmagicala/gnomeRestaurant/recipe/RecipeInstruction.java
+++ b/src/main/java/io/github/mmagicala/gnomeRestaurant/recipe/RecipeInstruction.java
@@ -37,7 +37,7 @@ public enum RecipeInstruction {
     POUR("Pour mix into the cocktail glass"),
     HEAT_COCKTAIL("Heat the cocktail"),
 
-    DELIVER("Deliver the item to recipient");
+    DELIVER("Deliver the item");
 
     private final String overlayDirections;
 


### PR DESCRIPTION
This PR tries to solve the same problem as #4, but with another approach, given that the current codebase no longer parses dialog.

I added the customer and order info to the header of the overlay, and it gets colorized if that customer provides unique reward.

For future proofing, just in case someone wants to use this information for some other info display, I've implemented the info on unique rewards as a field containing all unique reward that particular customer provides.

The commits are nicely split up for an easier review.